### PR TITLE
VM network

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            buildConfigField "boolean", "SKIP_P2P", "true"
+            buildConfigField "String", "SERVER_ADDR", "\"10.0.2.2\""
+        }
     }
     externalNativeBuild {
         cmake {

--- a/app/src/main/java/com/amos/flyinn/WifiP2PActivity.java
+++ b/app/src/main/java/com/amos/flyinn/WifiP2PActivity.java
@@ -3,6 +3,7 @@ package com.amos.flyinn;
 import android.Manifest;
 import android.app.ListActivity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.net.wifi.p2p.WifiP2pConfig;
@@ -37,6 +38,12 @@ public class WifiP2PActivity extends ListActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (BuildConfig.SKIP_P2P) {
+            Intent main = new Intent(this, MainActivity.class);
+            startActivity(main);
+            return;
+        }
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED){
             Toast.makeText(this,"Requesting permission for peers",Toast.LENGTH_SHORT).show();

--- a/create_vm_network.sh
+++ b/create_vm_network.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -e
+
+# get valid emulator ports
+get_emulators() {
+	adb devices | grep -Po 'emulator-\d+' | cut -d - -f 2
+}
+
+# auth token needed for admin operations in emulator console
+get_auth_token() {
+	cat $HOME/.emulator_console_auth_token
+}
+
+# Call telnet commands with sleep for latency
+call_fun() {
+	sleep 1
+	echo "auth $(get_auth_token)"
+
+	echo "ping"
+	echo "$1"
+	echo "ping"
+
+	sleep 1
+	echo "quit"
+}
+
+# execute command on the emulator console of the given vm
+# 1 - host port
+# 2 - command
+exec_emulator_console() {
+	port="$1"
+	call_fun "$2" | telnet 127.0.0.1 "$port" 2>/dev/null | sed -n '/I am alive!/,/I am alive!/p' | sed '/OK/d;1,2d;$d'
+}
+
+# get routing redirections for the given vm
+# 1 - host port
+get_redirections() {
+	port="$1"
+	exec_emulator_console "$port" "redir list"
+}
+
+redir_server() {
+	port="$1"
+	exec_emulator_console "$port" "redir add $2"
+}
+
+undo_redir() {
+	port="$1"
+	exec_emulator_console "$port" "redir del $2"
+}
+
+test_redir() {
+	redir_server $1 "tcp:1337:1337"
+	get_redirections $1
+	undo_redir $1 "tcp:1337"
+	get_redirections $1
+}
+
+if [ -z "$1" ]; then
+	echo "Available emulator ports:"
+	get_emulators
+	echo "Use args: <server_port>"
+	exit
+fi
+
+case "$1" in
+	test)
+		test_redir 5554
+		;;
+	auto)
+		echo "Auto redir 5554"
+		echo "Redirecting 1337 for event sender"
+		redir_server 5554 "tcp:1337:1337"
+		echo "Redirecting 8080 for webrtc"
+		redir_server 5554 "tcp:8080:8080"
+		get_redirections 5554 "tcp:1337:1337"
+		;;
+	*)
+		echo "test - Create and delete redir"
+		echo "auto - Create webrtc and event sender redir on first vm"
+esac

--- a/create_vm_network.sh
+++ b/create_vm_network.sh
@@ -4,7 +4,7 @@ set -e
 
 # get valid emulator ports
 get_emulators() {
-	adb devices | grep -Po 'emulator-\d+' | cut -d - -f 2
+	adb devices | grep -o "emulator-[0-9]\+" | cut -d '-' -f 2
 }
 
 # auth token needed for admin operations in emulator console

--- a/create_vm_network.sh
+++ b/create_vm_network.sh
@@ -74,6 +74,7 @@ case "$1" in
 		redir_server 5554 "tcp:1337:1337"
 		echo "Redirecting 8080 for webrtc"
 		redir_server 5554 "tcp:8080:8080"
+		redir_server 5554 "udp:8080:8080"
 		get_redirections 5554 "tcp:1337:1337"
 		;;
 	*)

--- a/create_vm_network.sh
+++ b/create_vm_network.sh
@@ -64,6 +64,11 @@ if [ -z "$1" ]; then
 	exit
 fi
 
+if ! command -v telnet; then
+	echo "telnet needs to be installed"
+	exit
+fi
+
 case "$1" in
 	test)
 		test_redir 5554

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,6 +38,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+
+        debug {
+            buildConfigField "boolean", "SKIP_P2P", "true"
+        }
     }
 
     testOptions {

--- a/server/src/main/AndroidManifest.xml
+++ b/server/src/main/AndroidManifest.xml
@@ -31,6 +31,9 @@
         </activity>
         <activity android:name=".WebRTCServerActivity"></activity>
         <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".EventGrabDemo"

--- a/server/src/main/java/com/amos/server/P2PActivityServer.java
+++ b/server/src/main/java/com/amos/server/P2PActivityServer.java
@@ -3,6 +3,7 @@ package com.amos.server;
 import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.net.wifi.p2p.WifiP2pManager;
@@ -28,6 +29,13 @@ public class P2PActivityServer extends Activity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Skip Wifi P2P if we are in a debug build with SKIP_P2P set to true
+        if (BuildConfig.SKIP_P2P) {
+            Intent intentToWebRTC = new Intent(this, MainActivity.class);
+            startActivity(intentToWebRTC);
+            return;
+        }
 
 
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED){


### PR DESCRIPTION
Script to expose VM networks works. The script uses commands outlined here: https://developer.android.com/studio/run/emulator-networking

**Testing**

```
# Expose VM network ports 1337 and 8080
./create_vm_network.sh auto

# check that we can reach these ports in the server
nc -zv 127.0.0.1 1337
nc -zv 127.0.0.1 8080
```

**Issues**

App doesn't work yet and won't connect to the server.

fakeinputlib can't be deployed, because the current folder has insufficient permissions in the emulator

Manually testing fakeinputlib seems to crash after connecting. This still needs to be debugged.

Why webrtc doesn't work I do not know.

@sbritocorral PTAL